### PR TITLE
🚨 Add Request Handler to Remove Repetitive Http Error Handling

### DIFF
--- a/cloudfunctions/cloudfunctions.go
+++ b/cloudfunctions/cloudfunctions.go
@@ -60,23 +60,23 @@ func inferBaseURL(projectID string, region string) (baseURL string) {
 }
 
 func LinkAccount(w http.ResponseWriter, r *http.Request) {
-	sc.StartFitbitOauthFlow(w, r)
+	stepcurry.Handler(sc.StartFitbitOauthFlow).ServeHTTP(w, r)
 }
 
 func Challenge(w http.ResponseWriter, r *http.Request) {
-	sc.Challenge(w, r)
+	stepcurry.Handler(sc.Challenge).ServeHTTP(w, r)
 }
 
 func UpdateChallenge(w http.ResponseWriter, r *http.Request) {
-	sc.UpdateChallenge(w, r)
+	stepcurry.Handler(sc.UpdateChallenge).ServeHTTP(w, r)
 }
 
 func HandleFitbitAuth(w http.ResponseWriter, r *http.Request) {
-	sc.HandleFitbitAuth(w, r)
+	stepcurry.Handler(sc.HandleFitbitAuth).ServeHTTP(w, r)
 }
 
 func Standings(w http.ResponseWriter, r *http.Request) {
-	sc.Standings(w, r)
+	stepcurry.Handler(sc.Standings).ServeHTTP(w, r)
 }
 
 func InvokeSlackAuth(w http.ResponseWriter, r *http.Request) {
@@ -84,5 +84,5 @@ func InvokeSlackAuth(w http.ResponseWriter, r *http.Request) {
 }
 
 func HandleSlackAuth(w http.ResponseWriter, r *http.Request) {
-	sc.HandleSlackAuth(w, r)
+	stepcurry.Handler(sc.HandleSlackAuth).ServeHTTP(w, r)
 }

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,49 @@
+package stepcurry
+
+import (
+	"log"
+	"net/http"
+)
+
+// httpError holds an application error and attributes to return a proper
+// http response to the caller
+type httpError struct {
+	err     error
+	message string
+	code    int
+}
+
+func newHttpError(err error, message string, code int) (herr *httpError) {
+	herr = new(httpError)
+	herr.err = err
+	herr.message = message
+	herr.code = code
+
+	return herr
+}
+
+func (e *httpError) Error() string {
+	return e.err.Error()
+}
+
+// Handler is a http.HandlerFunc that returns an error
+type Handler func(http.ResponseWriter, *http.Request) error
+
+// ServerHTTP runs the requestHandler and returns an error with the appropriate code if an error is returned
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := h(w, r)
+	if err != nil {
+		if herr, ok := err.(*httpError); ok {
+			if len(herr.message) > 0 {
+				log.Printf("%s: %s", herr.message, herr.Error())
+			} else {
+				log.Printf("%s", herr.Error())
+			}
+
+			http.Error(w, herr.Error(), herr.code)
+		} else {
+			log.Print(err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,63 @@
+package stepcurry
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandlerServing(t *testing.T) {
+	tests := map[string]struct {
+		handler        Handler
+		expectedResult int
+		expectedBody   string
+	}{
+		"NoError": {
+			handler: func(w http.ResponseWriter, r *http.Request) error {
+				w.Write([]byte("success"))
+				return nil
+			},
+			expectedResult: http.StatusOK,
+			expectedBody:   "success",
+		},
+		"StringError": {
+			handler: func(http.ResponseWriter, *http.Request) error {
+				return errors.New("something wrong")
+			},
+			expectedResult: http.StatusInternalServerError,
+			expectedBody:   "something wrong\n",
+		},
+		"HttpErrorWithoutMessage": {
+			handler: func(http.ResponseWriter, *http.Request) error {
+				return newHttpError(errors.New("some error"), "", http.StatusBadGateway)
+			},
+			expectedResult: http.StatusBadGateway,
+			expectedBody:   "some error\n",
+		},
+		"HttpErrorWithMessage": {
+			handler: func(http.ResponseWriter, *http.Request) error {
+				return newHttpError(errors.New("some invalid state"), "Bad internal state for user [x]", http.StatusInternalServerError)
+			},
+			expectedResult: http.StatusInternalServerError,
+			expectedBody:   "some invalid state\n",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", strings.NewReader(""))
+			w := httptest.NewRecorder()
+			Handler(tc.handler).ServeHTTP(w, r)
+
+			resp := w.Result()
+			rbody, _ := ioutil.ReadAll(resp.Body)
+
+			assert.Equal(t, tc.expectedResult, resp.StatusCode)
+			assert.Equal(t, tc.expectedBody, string(rbody))
+		})
+	}
+}


### PR DESCRIPTION
Taking inspiration from https://blog.golang.org/error-handling-and-go to improve error handling a bit. The prior pattern was logging some content with an error to be able to have something to look at in the console logs and then returning an appropriate http error (status and message). 